### PR TITLE
support node20 with fetch that must use duplex of requestInit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otakustay/bce-sdk",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "Yet another Baidu Cloud SDK",
   "type": "module",
   "exports": {

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -149,13 +149,16 @@ export class Http {
             {timestamp}
         );
 
+        const requestInit = {
+            method,
+            headers,
+            body: isPlainObject(options?.body) ? JSON.stringify(options?.body) : (options?.body ?? null),
+            duplex: 'half',
+        };
+
         const response = await fetch(
             this.baseUrl + url + (searchParams ? `?${searchParams}` : ''),
-            {
-                method,
-                headers,
-                body: isPlainObject(options?.body) ? JSON.stringify(options?.body) : (options?.body ?? null),
-            }
+            requestInit,
         );
 
         const responseHeaders = entriesToRecord([...response.headers.entries()]);


### PR DESCRIPTION
requestInit之所以单独拎出来，ts检查requestInit 类型中不应该包含 duplex，实际上ts应该支持了，改了ts版本不好使。

参考：
https://github.com/nodejs/node/issues/46221
https://github.com/bluesky-social/atproto/pull/470/files
https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483